### PR TITLE
Add CLI cold call app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+leads.csv
+results.csv
+__pycache__/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,29 @@
-# Seu-Resultado
+# App de Cold Call
+
+Este projeto fornece um aplicativo de linha de comando para auxiliar o time comercial durante cold calls. Os contatos são lidos de uma planilha do Google Sheets e o resultado de cada ligação é salvo em `results.csv`.
+
+## Como usar
+
+1. **Obter os leads**
+   - Exporte a planilha do Google para um arquivo CSV chamado `leads.csv` e coloque-o na raiz do projeto; **ou**
+   - Permita que o script faça o download direto informando o ID da planilha com `--sheet-id`.
+2. **Executar o aplicativo**
+
+   ```bash
+   python app.py --csv sample_leads.csv
+   ```
+
+   Substitua `sample_leads.csv` pelo seu arquivo `leads.csv` ou remova `--csv` para que o script tente baixar a planilha.
+3. **Registrar o resultado**
+   - Para cada contato exibido, informe `s` para sucesso, `n` para não atendeu, `p` para passar ou `q` para sair.
+4. **Consultar os resultados**
+   - As respostas serão salvas em `results.csv`.
+
+## Dependências
+
+- Python 3
+- Nenhuma biblioteca externa é necessária; o script utiliza apenas bibliotecas da distribuição padrão.
+
+## Exemplo de dados
+
+O arquivo `sample_leads.csv` contém um conjunto fictício de leads para teste.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,71 @@
+import argparse
+import csv
+import io
+import urllib.request
+
+DEFAULT_SHEET_ID = "1aZeWcd1p9decL2-CpZRigQ0CRZrRADEtLOqFKm4PHnU"
+CSV_EXPORT = "https://docs.google.com/spreadsheets/d/{}/export?format=csv"
+
+def load_leads_from_sheet(sheet_id: str):
+    """Download leads from a public Google Sheet and return as list of dicts."""
+    url = CSV_EXPORT.format(sheet_id)
+    with urllib.request.urlopen(url) as response:
+        data = response.read().decode("utf-8")
+    return list(csv.DictReader(io.StringIO(data)))
+
+
+def load_leads_from_file(path: str):
+    """Load leads from a local CSV file."""
+    with open(path, newline="", encoding="utf-8") as f:
+        return list(csv.DictReader(f))
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Ferramenta simples para cold calls baseada em uma planilha Google"
+    )
+    parser.add_argument(
+        "--sheet-id", default=DEFAULT_SHEET_ID, help="ID da planilha do Google Sheets"
+    )
+    parser.add_argument(
+        "--csv", help="Caminho para um arquivo CSV local (ignora --sheet-id se informado)"
+    )
+    args = parser.parse_args()
+
+    try:
+        if args.csv:
+            leads = load_leads_from_file(args.csv)
+        else:
+            leads = load_leads_from_sheet(args.sheet_id)
+    except Exception as exc:
+        print(f"Falha ao carregar leads: {exc}")
+        return
+
+    if not leads:
+        print("Nenhum lead encontrado.")
+        return
+
+    outcomes = {"s": "sucesso", "n": "nao atendeu", "p": "passar"}
+    results = []
+
+    for lead in leads:
+        print("\n--- Próximo contato ---")
+        for key, value in lead.items():
+            print(f"{key}: {value}")
+        action = input("Resultado (s=sucesso, n=nao atendeu, p=passar, q=sair): ").strip().lower()
+        if action == "q":
+            break
+        resultado = outcomes.get(action, "indefinido")
+        results.append({**lead, "resultado": resultado})
+
+    if results:
+        fieldnames = list(results[0].keys())
+        with open("results.csv", "w", newline="", encoding="utf-8") as f:
+            writer = csv.DictWriter(f, fieldnames=fieldnames)
+            writer.writeheader()
+            writer.writerows(results)
+        print(f"Resultados salvos em results.csv ({len(results)} registros).")
+
+
+if __name__ == "__main__":
+    main()

--- a/sample_leads.csv
+++ b/sample_leads.csv
@@ -1,0 +1,4 @@
+nome,telefone,empresa
+Maria,555-0100,Empresa A
+João,555-0101,Empresa B
+Ana,555-0102,Empresa C


### PR DESCRIPTION
## Summary
- implement simple command-line tool to fetch leads from a Google Sheet or local CSV and log call outcomes
- document usage and provide sample CSV data

## Testing
- `python -m py_compile app.py`
- `python app.py --help`
- `python app.py --csv sample_leads.csv`


------
https://chatgpt.com/codex/tasks/task_e_689a6ee3bebc8331950face7d62242d4